### PR TITLE
ci: separate Continuous Integration (CI) workflows per language

### DIFF
--- a/.github/workflows/go-continuous-integration.yml
+++ b/.github/workflows/go-continuous-integration.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: [go/aws, go/local, nodejs/aws, nodejs/local, python3/aws, python3/local, rust/aws, rust/local]
+        directory: [go/aws, go/local]
+        language: [go, shell]
     steps:
       - name: Download Earthly v0.8.12.
         uses: earthly/actions-setup@v1
@@ -21,13 +22,14 @@ jobs:
       - name: Checkout code.
         uses: actions/checkout@v4
       - name: Check formatting.
-        run: cd "${{ matrix.directory }}" && earthly --ci +check-formatting
+        run: cd "${{ matrix.directory }}" && earthly --ci +check-${{ matrix.language }}-formatting
   linting:
     name: Linting
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: [go/aws, go/local, nodejs/aws, nodejs/local, python3/aws, python3/local, rust/aws, rust/local]
+        directory: [go/aws, go/local]
+        language: [go, shell]
     steps:
       - name: Download Earthly v0.8.12.
         uses: earthly/actions-setup@v1
@@ -36,7 +38,7 @@ jobs:
       - name: Checkout code.
         uses: actions/checkout@v4
       - name: Check linting.
-        run: cd "${{ matrix.directory }}" && earthly --ci +check-linting
+        run: cd "${{ matrix.directory }}" && earthly --ci +check-${{ matrix.language }}-linting
   modules:
     name: Modules
     runs-on: ubuntu-latest
@@ -57,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: [go/aws, go/local, python3/aws, python3/local, rust/aws, rust/local]
+        directory: [go/aws, go/local]
     steps:
       - name: Download Earthly v0.8.12.
         uses: earthly/actions-setup@v1
@@ -72,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: [go/aws, go/local, rust/aws, rust/local]
+        directory: [go/aws, go/local]
     steps:
       - name: Download Earthly v0.8.12.
         uses: earthly/actions-setup@v1

--- a/.github/workflows/nodejs-continuous-integration.yml
+++ b/.github/workflows/nodejs-continuous-integration.yml
@@ -1,0 +1,41 @@
+name: Continuous Integration (CI)
+
+on: pull_request
+
+env:
+  # Forcing Earthly to use colours, to make reading output easier.
+  FORCE_COLOR: 1
+
+jobs:
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [nodejs/aws, nodejs/local]
+        language: [nodejs, shell]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Check formatting.
+        run: cd "${{ matrix.directory}}" && earthly --ci +check-${{ matrix.language }}-formatting
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [nodejs/aws, nodejs/local]
+        language: [shell]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Check linting.
+        run: cd "${{ matrix.directory}}" && earthly --ci +check-${{ matrix.language }}-linting

--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -1,0 +1,56 @@
+name: Continuous Integration (CI)
+
+on: pull_request
+
+env:
+  # Forcing Earthly to use colours, to make reading output easier.
+  FORCE_COLOR: 1
+
+jobs:
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [python3/aws, python3/local]
+        language: [python, shell]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Check formatting.
+        run: cd "${{ matrix.directory}}" && earthly --ci +check-${{ matrix.language }}-formatting
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [python3/aws, python3/local]
+        language: [shell]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Check linting.
+        run: cd "${{ matrix.directory}}" && earthly --ci +check-${{ matrix.language }}-linting
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [python3/aws, python3/local]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Compile.
+        run: cd "${{ matrix.directory}}" && earthly --ci +compile

--- a/.github/workflows/rust-continuous-integration.yml
+++ b/.github/workflows/rust-continuous-integration.yml
@@ -1,0 +1,71 @@
+name: Continuous Integration (CI)
+
+on: pull_request
+
+env:
+  # Forcing Earthly to use colours, to make reading output easier.
+  FORCE_COLOR: 1
+
+jobs:
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [rust/aws, rust/local]
+        language: [rust, shell]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Check formatting.
+        run: cd "${{ matrix.directory}}" && earthly --ci +check-${{ matrix.language }}-formatting
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [rust/aws, rust/local]
+        language: [rust, shell]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Check linting.
+        run: cd "${{ matrix.directory}}" && earthly --ci +check-${{ matrix.language }}-linting
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [rust/aws, rust/local]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Compile.
+        run: cd "${{ matrix.directory}}" && earthly --ci +compile
+  unit-test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [rust/aws, rust/local]
+    steps:
+      - name: Download Earthly v0.8.12.
+        uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.12
+      - name: Checkout code.
+        uses: actions/checkout@v4
+      - name: Unit test.
+        run: cd "${{ matrix.directory}}" && earthly --ci +unit-test


### PR DESCRIPTION
We are not displaying the Continuous Integration (CI) badges anymore, so no
reason to have a singular workflow. How we implemented a single workflow removed
granularity from the checks, so just reverting back to a per language workflow.

Reverts d04b8f96ce52bacb2d3fa9f77af54cf16ff8ca4d

